### PR TITLE
ddlの修正

### DIFF
--- a/api/app/schema/ddl.sql
+++ b/api/app/schema/ddl.sql
@@ -16,9 +16,9 @@ CREATE TABLE IF NOT EXISTS `posts` (
     `img` LONGTEXT,
     `created_at` DATETIME NOT NULL,
     `updated_at` DATETIME NOT NULL,
-    PRIMARY KEY (id),
-    FOREIGN KEY (user_id)
-    REFERENCES `users`(id)
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`user_id`)
+    REFERENCES `users`(`id`)
     ON UPDATE CASCADE ON DELETE CASCADE
 )  ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 
@@ -30,14 +30,14 @@ CREATE TABLE IF NOT EXISTS `comments` (
     `img` LONGTEXT,
     `created_at` DATETIME NOT NULL,
     `updated_at` DATETIME NOT NULL,
-    PRIMARY KEY (id),
+    PRIMARY KEY (`id`),
 
-    FOREIGN KEY (post_id)
-    REFERENCES `posts`(id)
+    FOREIGN KEY (`post_id`)
+    REFERENCES `posts`(`id`)
     ON UPDATE CASCADE ON DELETE CASCADE,
 
-    FOREIGN KEY (user_id)
-    REFERENCES `users`(id)
+    FOREIGN KEY (`user_id`)
+    REFERENCES `users`(`id`)
     ON UPDATE CASCADE ON DELETE CASCADE
 )  ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 
@@ -45,17 +45,17 @@ CREATE TABLE IF NOT EXISTS `likes` (
     `id` INT NOT NULL AUTO_INCREMENT,
     `post_id` INT NOT NULL,
     `user_id` INT NOT NULL,
-    PRIMARY KEY (id),
-    UNIQUE post_user_id_index (post_id, user_id),
+    PRIMARY KEY (`id`),
+    UNIQUE `post_user_id_index` (`post_id`, `user_id`),
 
-    INDEX (post_id),
-    INDEX (user_id),
+    INDEX (`post_id`),
+    INDEX (`user_id`),
 
-    FOREIGN KEY (post_id)
-    REFERENCES `posts`(id)
+    FOREIGN KEY (`post_id`)
+    REFERENCES `posts`(`id`)
     ON UPDATE CASCADE ON DELETE CASCADE,
 
-    FOREIGN KEY (user_id)
-    REFERENCES `users`(id)
+    FOREIGN KEY (`user_id`)
+    REFERENCES `users`(`id`)
     ON UPDATE CASCADE ON DELETE CASCADE
 )  ENGINE=InnoDB  DEFAULT CHARSET=utf8;


### PR DESCRIPTION
`RESTRICT`から`CASCADE`に変更しました！
下記参照
<img width="615" alt="image" src="https://user-images.githubusercontent.com/74532799/191222044-2a67e4c9-4e2b-469b-b307-50a36339dadd.png">

dbのテーブル更新するためのコマンド↓
```
ALTER TABLE `likes` ADD FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`) ON UPDATE CASCADE ON DELETE CASCADE;
```
```
ALTER TABLE `likes` ADD FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON UPDATE CASCADE ON DELETE CASCADE;
```
```
ALTER TABLE `comments` ADD FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON UPDATE CASCADE ON DELETE CASCADE;
```
```
ALTER TABLE `comments` ADD FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`) ON UPDATE CASCADE ON DELETE CASCADE;
```
```
ALTER TABLE `posts` ADD FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON UPDATE CASCADE ON DELETE CASCADE;
```

エラー出たとき
```
 delete from likes where post_id not in(select id from posts);
```
```
delete from comments where post_id not in(select id from posts);
```