### PR TITLE
:bug: ユーザーの詳細ページで投稿したデータがない時にエラーを吐かないように修正

### DIFF
--- a/api/app/interactor/post.go
+++ b/api/app/interactor/post.go
@@ -2,6 +2,8 @@ package interactor
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 
 	"github.com/google/wire"
 	"github.com/kod-source/docker-goa-next/app/model"
@@ -74,6 +76,9 @@ func (p *postInteractor) Show(ctx context.Context, id int) (*model.ShowPost, err
 func (p *postInteractor) ShowMyLike(ctx context.Context, userID, nextID int) ([]*model.IndexPostWithCountLike, *int, error) {
 	ips, nID, err := p.pr.ShowMyLike(ctx, userID, nextID)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil, nil
+		}
 		return nil, nil, err
 	}
 
@@ -84,6 +89,9 @@ func (p *postInteractor) ShowMyLike(ctx context.Context, userID, nextID int) ([]
 func (p *postInteractor) ShowPostMy(ctx context.Context, userID, nextID int) ([]*model.IndexPostWithCountLike, *int, error) {
 	ips, nID, err := p.pr.ShowPostMy(ctx, userID, nextID)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil, nil
+		}
 		return nil, nil, err
 	}
 
@@ -93,6 +101,9 @@ func (p *postInteractor) ShowPostMy(ctx context.Context, userID, nextID int) ([]
 func (p *postInteractor) ShowPostMedia(ctx context.Context, userID, nextID int) ([]*model.IndexPostWithCountLike, *int, error) {
 	ips, nID, err := p.pr.ShowPostMedia(ctx, userID, nextID)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil, nil
+		}
 		return nil, nil, err
 	}
 	return ips, nID, nil

--- a/client/lib/components/showPostMy.tsx
+++ b/client/lib/components/showPostMy.tsx
@@ -53,21 +53,26 @@ export const ShowPostMy: FC<Props> = ({
 
     const fetchData = async () => {
         if (nextID == null) return;
-        setIsLoading(true);
-        const allPostLimit =
-            value === UserPostSelection.My
-                ? await PostRepository.showPostMy(nextID, showUser.id)
-                : value === UserPostSelection.Media
-                ? await PostRepository.showPostMedia(nextID, showUser.id)
-                : await PostRepository.showPostLike(nextID, showUser.id);
-        setNextID(allPostLimit.nextId);
-        setPostsWithUser((old) => {
-            if (nextID === 0) {
-                return allPostLimit.postsWithUsers;
+        try {
+            setIsLoading(true);
+            const allPostLimit =
+                value === UserPostSelection.My
+                    ? await PostRepository.showPostMy(nextID, showUser.id)
+                    : value === UserPostSelection.Media
+                    ? await PostRepository.showPostMedia(nextID, showUser.id)
+                    : await PostRepository.showPostLike(nextID, showUser.id);
+            setPostsWithUser((old) => {
+                if (nextID === 0) {
+                    return allPostLimit.postsWithUsers;
+                }
+                return [...old, ...allPostLimit.postsWithUsers];
+            });
+            setIsLoading(false);
+        } catch (e) {
+            if (e instanceof Error) {
+                alert(e.message);
             }
-            return [...old, ...allPostLimit.postsWithUsers];
-        });
-        setIsLoading(false);
+        }
     };
 
     useEffect(() => {


### PR DESCRIPTION
## 概要
ユーザーの詳細ページで投稿やいいねなどがない時にエラーが発生しないように修正

## 修正内容
- [x] client側でAPIを叩くときに`try catch`を付けて実行する
- [x] api側でDatastore層で404が帰ってきたらクライアント側には空の配列を返すようにする

